### PR TITLE
Add hashed release assets with manifest

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,48 @@
+name: Release frontend assets
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  build-and-upload:
+    name: Build and upload web component
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10.15.1
+          run_install: false
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build web component
+        run: pnpm -C frontend build
+
+      - name: Generate asset manifest
+        run: |
+          node -e "const fs=require('fs'); const path='frontend/dist'; const files=fs.readdirSync(path); const js=files.find(f=>/^pamphlet-viewer-.*\\.js$/.test(f)); const css=files.find(f=>/^pamphlet-viewer-.*\\.css$/.test(f)); if(!js||!css){throw new Error('JS/CSS assets not found');} fs.writeFileSync(`${path}/pamphlet-viewer-assets.json`, JSON.stringify({ js, css }, null, 2));"
+
+      - name: Upload release assets
+        uses: softprops/action-gh-release@v2
+        with:
+          files: |
+            frontend/dist/pamphlet-viewer-*.js
+            frontend/dist/pamphlet-viewer-*.css
+            frontend/dist/pamphlet-viewer-assets.json
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -53,9 +53,30 @@ pnpm build
 ```
 
 ビルド成果物は `dist/` に出力されます：
-- `pamphlet-viewer.js` - ESM形式
-- `pamphlet-viewer.umd.cjs` - UMD形式
-- `pamphlet-viewer.css` - スタイル
+- `pamphlet-viewer-<hash>.js` - ESM形式（コンテンツハッシュ付き）
+- `pamphlet-viewer-<hash>.css` - スタイル（コンテンツハッシュ付き）
+- `pamphlet-viewer-assets.json` - 上記ファイル名を示すマニフェスト
+
+GitHub Releaseにそのまま添付して配布することを想定しています。ブラウザキャッシュを確実に更新するため、JS/CSSにはコンテンツハッシュを付与しています。`latest` リリースにアップロードした場合でも、安定したURLは `pamphlet-viewer-assets.json` です。このマニフェストを取得し、記載されたハッシュ付きファイルを読み込むようにしてください：
+
+```html
+<script type="module">
+  const base = 'https://github.com/OWNER/web-pamphlet-viewer/releases/latest/download/';
+
+  const manifest = await fetch(`${base}pamphlet-viewer-assets.json`).then((res) => res.json());
+
+  const css = document.createElement('link');
+  css.rel = 'stylesheet';
+  css.href = `${base}${manifest.css}`;
+  document.head.appendChild(css);
+
+  await import(`${base}${manifest.js}`);
+</script>
+```
+
+`OWNER` はリポジトリの所有者に置き換えてください。特定のタグで固定する場合は `latest` の部分を `v1.2.3` などのタグ名に変更するだけで済み、手元へのコピー作業は不要です。マニフェストは常に固定名なので、キャッシュ更新の心配なくハッシュ付きの最新アセットを読み込めます。
+
+リリース資産は `.github/workflows/release.yml` のGitHub Actionsで自動ビルド＆添付されます。リポジトリでタグ付きのReleaseを発行すると、上記のファイルがRelease Assetsに追加され、即座に公開URLから取得できるようになります。
 
 ### 型チェック
 

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -1,11 +1,34 @@
 import { defineConfig } from 'vite';
 import { svelte } from '@sveltejs/vite-plugin-svelte';
 import tailwindcss from '@tailwindcss/vite';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const distDir = path.resolve(fileURLToPath(new URL('.', import.meta.url)), 'dist');
+
+const assetManifestPlugin = () => ({
+  name: 'pamphlet-viewer-asset-manifest',
+  writeBundle(_, bundle) {
+    const outputs = Object.values(bundle);
+    const js = outputs.find((chunk) => chunk.type === 'chunk' && /^pamphlet-viewer-.*\.js$/.test(chunk.fileName));
+    const css = outputs.find((asset) => asset.type === 'asset' && typeof asset.fileName === 'string' && /^pamphlet-viewer-.*\.css$/.test(asset.fileName));
+
+    if (!js || !css) return;
+
+    fs.mkdirSync(distDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(distDir, 'pamphlet-viewer-assets.json'),
+      JSON.stringify({ js: js.fileName, css: css.fileName }, null, 2)
+    );
+  }
+});
 
 export default defineConfig({
   plugins: [
     svelte(),
-    tailwindcss()
+    tailwindcss(),
+    assetManifestPlugin()
   ],
   build: {
     lib: {
@@ -15,9 +38,15 @@ export default defineConfig({
     },
     rollupOptions: {
       output: {
-        entryFileNames: 'pamphlet-viewer.[hash].js',
-        chunkFileNames: 'pamphlet-viewer.[hash].js',
-        assetFileNames: 'pamphlet-viewer.[hash].[ext]'
+        entryFileNames: 'pamphlet-viewer-[hash].js',
+        chunkFileNames: 'pamphlet-viewer-[hash].js',
+        assetFileNames: (assetInfo) => {
+          if (assetInfo.name?.endsWith('.css')) {
+            return 'pamphlet-viewer-[hash][extname]';
+          }
+
+          return '[name][extname]';
+        },
       }
     }
   }


### PR DESCRIPTION
## Summary
- add content-hashed JS/CSS filenames for the web component build and emit a manifest
- update the release workflow to upload the hashed assets and manifest
- document how to load the hashed assets via the manifest to avoid browser caching issues

## Testing
- pnpm -C frontend build

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6937728762048330a5bb92dcfa18cab1)